### PR TITLE
Cygwin compatibility bugfix

### DIFF
--- a/apiary2postman/blueprint.py
+++ b/apiary2postman/blueprint.py
@@ -11,10 +11,7 @@ def fetch_blueprint(name, key):
 	return response_body['code']
 
 def blueprint2json(blueprint):
-	t = NamedTemporaryFile()
-	p = Popen(['snowcrash', '--format', 'json', '--output', t.name], stdin=PIPE, stdout=PIPE, stderr=PIPE)
-	p.communicate(blueprint)
-	out = t.read()
-	t.close()
+	p = Popen(['snowcrash', '--format', 'json'], stdin=PIPE, stdout=PIPE, stderr=PIPE)
+	out, err = p.communicate(blueprint)
 	return out
 	


### PR DESCRIPTION
I tried to run apiary2postman on windows under cygwin. Due to check with command "which" I cannot use standard command line.

NamedTemporaryFile under cygwin uses Unix-like folders tree, so temp folder is usually located under /tmp. Unfortunately when you start process via Popopen it runs in windows environment where folder /tmp is not available.

I don't know why author used NamedTemporaryFile but on the Windows it works perfectly without it.
