### PR TITLE
Fixes #3: --only-collection exports only first collection

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
-dist/*
+build/
+dist/

--- a/MANIFEST
+++ b/MANIFEST
@@ -2,6 +2,6 @@
 setup.cfg
 setup.py
 apiary2postman/__init__.py
-apiary2postman/apiary.py
 apiary2postman/apiary2postman.py
+apiary2postman/blueprint.py
 apiary2postman/converter.py


### PR DESCRIPTION
I have fixed #3, but I do however think the whole current approach of the script is off. Currently it is trying to make a new collection for every single resource group, which seems a bit OTT. I work on multiple APIs and each one of those is its own collection, and not just each resource for a specific API.

With this PR, the `--only-collection` switch will merge all resource groups into one collection. This seems logical in my use-case, but I am struggling to work out what is the best fit for this script without changing the whole darn thing. 
