### PR TITLE
Adding order field, setting correct collectionId

### DIFF
--- a/apiary2postman/converter.py
+++ b/apiary2postman/converter.py
@@ -98,6 +98,7 @@ def parseResourceGroups(resourceGroups, environment_vals, only_collection):
 		collection['timestamp'] = int(time())
 		collection['synced'] = False
 		collection['remote_id'] = 0
+		collection['order'] = []
 
 		for resource in resourceGroup['resources']:		
 			folder = dict()
@@ -157,8 +158,9 @@ def parseResourceGroups(resourceGroups, environment_vals, only_collection):
 							headers.append('Accept: ' + header['value'])
 
 				request['headers'] = '\n'.join(headers)
-				# Add reference to folder to this request
-				request['collectionId'] = folder['id']
+				# Add reference to collection to this request
+				# The collectionId field refers to the parent collection, not the folder
+				request['collectionId'] = collection['id']
 				# Add reference to the request to the current folder
 				folder['order'].append( request['id'] )
 				# Add request json to the collection


### PR DESCRIPTION
Collections exported from the converter were not being saved correctly in Postman. The collectionId field in the request always refers to the parent collection, not the parent folder. 
In Postman, no reference is needed from the request to the folder.

Also, a collection.order field is mandatory, otherwise all requests in the collection (even those within folders) will show up in the root collection.