### PR TITLE
windows fix

### DIFF
--- a/apiary2postman/apiary2postman.py
+++ b/apiary2postman/apiary2postman.py
@@ -15,7 +15,10 @@ def readInput():
 
 def check_drafter():
     try: 
-        subprocess.check_output(['which', 'drafter'])
+        if platform.startswith('win'):
+            subprocess.call(['drafter', '-v'], stdout=subprocess.PIPE) == 0
+        else:
+            subprocess.check_output(['which', 'drafter'])
     except: 
         print 'Please install drafter:'
         print ''


### PR DESCRIPTION
<b>apiary2postman</b> its a very nice tool, but when I run on my Windows machine it doesn't work. <b>apiary2postman</b> doesn't work, because you use 'drafter which' and this is a unix command. I created some fix, who check the system platform. When the system platform starts with 'win', I call  'drafter -v' command, if the command return 'returncode==0' the drafter exist.